### PR TITLE
fix: get full hash path in Google Analytics

### DIFF
--- a/portal/components/Content.js
+++ b/portal/components/Content.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 
 class Content extends React.Component {
   componentDidMount() {
-    ReactGA.pageview(window.location.pathname + window.location.search);
+    ReactGA.pageview(window.location.hash);
   }
 
   render() {


### PR DESCRIPTION
The portal was sending only the start page `/` to Google Analytics. Also when you visit another page it was sending `/`. Strange because yesterdag it was working properly (see GA history). After research it is better anyway to use `location.hash`